### PR TITLE
Correct ranges and enums for various preference values

### DIFF
--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -228,12 +228,12 @@
         "GPUTileCache": {
             "type": "integer",
             "multipleOf": 256,
-            "minimum": 1024
+            "minimum": 256
         },
         "systemTileCache": {
             "type": "integer",
             "multipleOf": 256,
-            "minimum": 1024
+            "minimum": 256
         },
         "contourDecimation": {
             "type": "integer",
@@ -248,14 +248,12 @@
         "contourChunkSize": {
             "type": "integer",
             "multipleOf": 25000,
-            "minimum": 25000,
-            "maximum": 1000000
+            "minimum": 25000
         },
         "contourControlMapWidth": {
             "type": "integer",
             "multipleOf": 128,
-            "minimum": 128,
-            "maximum": 1024
+            "minimum": 128
         },
         "streamContoursWhileZooming": {
             "type": "boolean"
@@ -265,8 +263,7 @@
         },
         "stopAnimationPlaybackMinutes": {
             "type": "number",
-            "minimum": 5,
-            "maximum": 30
+            "exclusiveMinimum": 0
         },
         "pixelGridVisible": {
             "type": "boolean"

--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -388,10 +388,12 @@
         },
         "pvPreviewCubeSizeLimit": {
             "type": "number",
-            "minimum": 0
+            "minimum": 0.1,
+            "description": "PV preview cube size limit, in GB."
         },
         "pvPreviewCubeSizeLimitUnit": {
-            "enum": ["TB", "GB", "MB", "kB", "B"]
+            "enum": ["TB", "GB", "MB", "kB", "B"],
+            "description": "This is a deprecated preference."
         },
         "logEventList": {
             "type": "array",

--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -164,7 +164,7 @@
         },
         "wcsType": {
             "type": "string",
-            "enum": ["Automatic", "Degrees", "Sexagesimal"]
+            "enum": ["automatic", "degrees", "sexagesimal"]
         },
         "colorbarVisible": {
             "type": "boolean"

--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -247,7 +247,7 @@
         },
         "contourChunkSize": {
             "type": "integer",
-            "minimum": 25000
+            "minimum": 1000
         },
         "contourControlMapWidth": {
             "type": "integer",
@@ -262,7 +262,7 @@
         },
         "stopAnimationPlaybackMinutes": {
             "type": "number",
-            "exclusiveMinimum": 0
+            "minimum": 0
         },
         "pixelGridVisible": {
             "type": "boolean"
@@ -388,7 +388,7 @@
         },
         "pvPreviewCubeSizeLimit": {
             "type": "number",
-            "exclusiveMinimum": 0
+            "minimum": 0
         },
         "pvPreviewCubeSizeLimitUnit": {
             "enum": ["TB", "GB", "MB", "kB", "B"]

--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -396,18 +396,21 @@
             "enum": ["GB", "MB"]
         },
         "if": {
+            "type": "object",
             "properties": {
                 "pvPreviewCubeSizeLimitUnit": {"const": "GB"}
             }
         },
         "then": {
+            "type": "object",
             "properties": {
-                "pvPreviewCubeSizeLimit": {"maximum": 1}
+                "pvPreviewCubeSizeLimit": {"type": "number", "maximum": 1}
             }
         },
         "else": {
+            "type": "object",
             "properties": {
-                "pvPreviewCubeSizeLimit": {"maximum": 1000}
+                "pvPreviewCubeSizeLimit": {"type": "number", "maximum": 1000}
             }
         },
         "logEventList": {

--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -247,7 +247,6 @@
         },
         "contourChunkSize": {
             "type": "integer",
-            "multipleOf": 25000,
             "minimum": 25000
         },
         "contourControlMapWidth": {

--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -221,7 +221,8 @@
         },
         "regionSize": {
             "type": "number",
-            "minimum": 1
+            "minimum": 10,
+            "maximum": 100
         },
         "imageCompressionQuality": {
             "type": "integer",
@@ -383,7 +384,8 @@
         },
         "pointAnnotationWidth": {
             "type": "number",
-            "minimum": 1
+            "minimum": 1,
+            "maximum": 100
         },
         "textAnnotationLineWidth": {
             "type": "number"

--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -18,7 +18,6 @@
             "minLength": 1
         },
         "theme": {
-            "type": "string",
             "enum": ["auto", "light", "dark"]
         },
         "autoLaunch": {
@@ -29,29 +28,24 @@
             "pattern": "^([+\\-])(date|filename|type|size)$"
         },
         "fileFilteringType": {
-            "type": "string",
             "enum": ["fuzzy", "unix", "regex"]
         },
         "layout": {
             "type": "string"
         },
         "cursorPosition": {
-            "type": "string",
             "enum": ["fixed", "tracking"]
         },
         "zoomMode": {
-            "type": "string",
             "enum": ["fit", "full"]
         },
         "zoomPoint": {
-            "type": "string",
             "enum": ["cursor", "center"]
         },
         "dragPanning": {
             "type": "boolean"
         },
         "spectralMatchingType": {
-            "type": "string",
             "enum": ["VRAD", "VOPT", "FREQ", "WAVE", "AWAV", "CHANNEL"]
         },
         "wcsMatchingType": {
@@ -72,17 +66,17 @@
             "type": "string"
         },
         "percentile": {
-            "type": "number",
-            "maximum": 100,
-            "minimum": 0
+            "enum": [90, 95, 99, 99.5, 99.9, 99.95, 99.99, 100]
         },
         "scalingAlpha": {
             "type": "number",
-            "minimum": 1
+            "minimum": 0.1,
+            "maximum": 1000000
         },
         "scalingGamma": {
             "type": "number",
-            "exclusiveMinimum": 0
+            "minimum": 0.1,
+            "maximum": 2
         },
         "nanColorHex": {
             "type": "string",
@@ -97,7 +91,6 @@
             "type": "boolean"
         },
         "contourGeneratorType": {
-            "type": "string",
             "enum": ["start-step-multiplier", "min-max-scaling", "percentages-ref.value", "mean-sigma-list"]
         },
         "contourSmoothingMode": {
@@ -107,15 +100,18 @@
         },
         "contourSmoothingFactor": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 1,
+            "maximum": 33
         },
         "contourNumLevels": {
             "type": "integer",
-            "minimum": 1
+            "minimum": 1,
+            "maximum": 15
         },
         "contourThickness": {
             "type": "number",
-            "minimum": 0
+            "minimum": 0.5,
+            "maximum": 10
         },
         "contourColormapEnabled": {
             "type": "boolean"
@@ -129,7 +125,8 @@
         },
         "vectorOverlayPixelAveraging": {
             "type": "number",
-            "minimum": 2,
+            "minimum": 0,
+            "maximum": 64,
             "default": 4
         },
         "vectorOverlayFractionalIntensity": {
@@ -138,7 +135,8 @@
         },
         "vectorOverlayThickness": {
             "type": "number",
-            "minimum": 0
+            "minimum": 0.5,
+            "maximum": 10
         },
         "vectorOverlayColormapEnabled": {
             "type": "boolean"
@@ -163,7 +161,6 @@
             "type": "boolean"
         },
         "wcsType": {
-            "type": "string",
             "enum": ["automatic", "degrees", "sexagesimal"]
         },
         "colorbarVisible": {
@@ -173,7 +170,6 @@
             "type": "boolean"
         },
         "colorbarPosition": {
-            "type": "string",
             "enum": ["right", "top", "bottom"]
         },
         "colorbarWidth": {
@@ -196,12 +192,12 @@
             "type": "string"
         },
         "beamType": {
-            "type": "string",
             "enum": ["open", "solid"]
         },
         "beamWidth": {
             "type": "number",
-            "minimum": 0
+            "minimum": 0.5,
+            "maximum": 10
         },
         "regionColor": {
             "type": "string",
@@ -209,19 +205,18 @@
         },
         "regionLineWidth": {
             "type": "number",
-            "minimum": 0
+            "minimum": 0.5,
+            "maximum": 10
         },
         "regionDashLength": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "maximum": 50
         },
         "regionType": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 6
+            "enum": [0, 1, 2, 3, 4, 6]
         },
         "regionCreationMode": {
-            "type": "string",
             "enum": ["center", "corner"]
         },
         "regionSize": {
@@ -230,23 +225,25 @@
         },
         "imageCompressionQuality": {
             "type": "integer",
-            "minimum": 4,
+            "minimum": 1,
             "maximum": 32
         },
         "animationCompressionQuality": {
             "type": "integer",
-            "minimum": 4,
+            "minimum": 1,
             "maximum": 32
         },
         "GPUTileCache": {
             "type": "integer",
             "multipleOf": 256,
-            "minimum": 1024
+            "minimum": 1024,
+            "maximum": 8192
         },
         "systemTileCache": {
             "type": "integer",
-            "multipleOf": 128,
-            "minimum": 1024
+            "multipleOf": 256,
+            "minimum": 1024,
+            "maximum": 16384
         },
         "contourDecimation": {
             "type": "integer",
@@ -259,16 +256,10 @@
             "maximum": 19
         },
         "contourChunkSize": {
-            "type": "integer",
-            "multipleOf": 25000,
-            "minimum": 25000,
-            "maximum": 1000000
+            "enum": [25000, 50000, 100000, 250000, 500000, 1000000]
         },
         "contourControlMapWidth": {
-            "type": "integer",
-            "multipleOf": 128,
-            "minimum": 128,
-            "maximum": 1024
+            "enum": [128, 256, 512, 1024]
         },
         "streamContoursWhileZooming": {
             "type": "boolean"
@@ -276,10 +267,8 @@
         "lowBandwidthMode": {
             "type": "boolean"
         },
-        "stopAnimationPlayback": {
-            "type": "integer",
-            "minimum": 5,
-            "maximum": 30
+        "stopAnimationPlaybackMinutes": {
+            "enum": [5, 10, 15, 20, 30]
         },
         "pixelGridVisible": {
             "type": "boolean"
@@ -295,7 +284,6 @@
             "default": true
         },
         "cursorInfoVisible": {
-            "type": "string",
             "enum": ["always", "activeImage", "hideTiled", "never"],
             "default": "activeImage"
         },
@@ -312,7 +300,6 @@
             "default": false
         },
         "imagePanelMode": {
-            "type": "string",
             "enum": ["dynamic", "fixed"],
             "default": "dynamic"
         },
@@ -339,7 +326,6 @@
             "type": "string"
         },
         "telemetryMode": {
-            "type": "string",
             "enum": ["none", "minimal", "usage"],
             "default": "usage"
         },
@@ -352,7 +338,6 @@
             "default": false
         },
         "fileFilterMode": {
-            "type": "string",
             "enum": ["content", "extension", "all"],
             "default": "content"
         },
@@ -383,10 +368,13 @@
             "type": "string"
         },
         "annotationLineWidth": {
-            "type": "number"
+            "type": "number",
+            "minimum": 0.5,
+            "maximum": 10
         },
         "annotationDashLength": {
-            "type": "number"
+            "type": "number",
+            "maximum": 50
         },
         "pointAnnotationShape": {
             "type": "integer",
@@ -394,20 +382,33 @@
             "maximum": 7
         },
         "pointAnnotationWidth": {
-            "type": "number"
+            "type": "number",
+            "minimum": 1
         },
         "textAnnotationLineWidth": {
             "type": "number"
         },
-        "stopAnimationPlaybackMinutes": {
-            "type": "number"
-        },
         "pvPreviewCubeSizeLimit": {
-            "type": "number"
+            "type": "number",
+            "minimum": 1e-12
         },
         "pvPreviewCubeSizeLimitUnit": {
-            "type": "string",
-            "enum": ["TB", "GB", "MB", "kB", "B"]
+            "enum": ["GB", "MB"]
+        },
+        "if": {
+            "properties": {
+                "pvPreviewCubeSizeLimitUnit": {"const": "GB"}
+            }
+        },
+        "then": {
+            "properties": {
+                "pvPreviewCubeSizeLimit": {"maximum": 1}
+            }
+        },
+        "else": {
+            "properties": {
+                "pvPreviewCubeSizeLimit": {"maximum": 1000}
+            }
         },
         "logEventList": {
             "type": "array",
@@ -416,7 +417,8 @@
             }
         },
         "catalogDisplayedColumnSize": {
-            "type": "number"
+            "type": "number",
+            "minimum": 1
         },
         "catalogTableSeparatorPosition": {
             "type": "string"

--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -12,11 +12,6 @@
             "minimum": 1,
             "maximum": 2
         },
-        "username": {
-            "description": "Deprecated option",
-            "type": "string",
-            "minLength": 1
-        },
         "theme": {
             "enum": ["auto", "light", "dark"]
         },
@@ -48,12 +43,6 @@
         "spectralMatchingType": {
             "enum": ["VRAD", "VOPT", "FREQ", "WAVE", "AWAV", "CHANNEL"]
         },
-        "wcsMatchingType": {
-            "description": "Deprecated option",
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 3
-        },
         "transparentImageBackground": {
             "type": "boolean"
         },
@@ -66,7 +55,9 @@
             "type": "string"
         },
         "percentile": {
-            "enum": [90, 95, 99, 99.5, 99.9, 99.95, 99.99, 100]
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100
         },
         "scalingAlpha": {
             "type": "number",
@@ -237,14 +228,12 @@
         "GPUTileCache": {
             "type": "integer",
             "multipleOf": 256,
-            "minimum": 1024,
-            "maximum": 8192
+            "minimum": 1024
         },
         "systemTileCache": {
             "type": "integer",
             "multipleOf": 256,
-            "minimum": 1024,
-            "maximum": 16384
+            "minimum": 1024
         },
         "contourDecimation": {
             "type": "integer",
@@ -257,10 +246,16 @@
             "maximum": 19
         },
         "contourChunkSize": {
-            "enum": [25000, 50000, 100000, 250000, 500000, 1000000]
+            "type": "integer",
+            "multipleOf": 25000,
+            "minimum": 25000,
+            "maximum": 1000000
         },
         "contourControlMapWidth": {
-            "enum": [128, 256, 512, 1024]
+            "type": "integer",
+            "multipleOf": 128,
+            "minimum": 128,
+            "maximum": 1024
         },
         "streamContoursWhileZooming": {
             "type": "boolean"
@@ -269,7 +264,9 @@
             "type": "boolean"
         },
         "stopAnimationPlaybackMinutes": {
-            "enum": [5, 10, 15, 20, 30]
+            "type": "number",
+            "minimum": 5,
+            "maximum": 30
         },
         "pixelGridVisible": {
             "type": "boolean"
@@ -389,32 +386,16 @@
             "maximum": 100
         },
         "textAnnotationLineWidth": {
-            "type": "number"
+            "type": "number",
+            "minimum": 0.5,
+            "maximum": 10
         },
         "pvPreviewCubeSizeLimit": {
             "type": "number",
-            "minimum": 1e-12
+            "exclusiveMinimum": 0
         },
         "pvPreviewCubeSizeLimitUnit": {
-            "enum": ["GB", "MB"]
-        },
-        "if": {
-            "type": "object",
-            "properties": {
-                "pvPreviewCubeSizeLimitUnit": {"const": "GB"}
-            }
-        },
-        "then": {
-            "type": "object",
-            "properties": {
-                "pvPreviewCubeSizeLimit": {"type": "number", "maximum": 1}
-            }
-        },
-        "else": {
-            "type": "object",
-            "properties": {
-                "pvPreviewCubeSizeLimit": {"type": "number", "maximum": 1000}
-            }
+            "enum": ["TB", "GB", "MB", "kB", "B"]
         },
         "logEventList": {
             "type": "array",

--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -73,8 +73,8 @@
         },
         "percentile": {
             "type": "number",
-            "exclusiveMaximum": 100,
-            "exclusiveMinimum": 0
+            "maximum": 100,
+            "minimum": 0
         },
         "scalingAlpha": {
             "type": "number",
@@ -164,7 +164,7 @@
         },
         "wcsType": {
             "type": "string",
-            "enum": ["automatic", "degrees", "sexagesimal"]
+            "enum": ["Automatic", "Degrees", "Sexagesimal"]
         },
         "colorbarVisible": {
             "type": "boolean"

--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -375,6 +375,7 @@
         },
         "annotationDashLength": {
             "type": "number",
+            "minimum": 0,
             "maximum": 50
         },
         "pointAnnotationShape": {


### PR DESCRIPTION
Fixes #8.

This PR corrects several restrictions on preference values which are out of sync with the frontend and cause unexpected behaviour because of schema validation errors.

These changes mostly affect the frontend, so I will describe the details in the related frontend issue.

I have removed the types from preferences which have values restricted to enums -- per the JSON schema docs, including them is considered bad practice, as the enum already implicitly determines the type(s).

Some constraints have been relaxed, so that limitations in the frontend input GUI don't restrict what valid values can be entered, and so that we don't make it unnecessarily difficult to change these input selections.

Companion PRs in the [backend](https://github.com/CARTAvis/carta-backend/pull/1486), [frontend](https://github.com/CARTAvis/carta-frontend/pull/2563), and [controller](https://github.com/CARTAvis/carta-controller/pull/239).