### PR TITLE
Support sinh/asinh scaling schema fields

### DIFF
--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -73,11 +73,6 @@
             "type": "string",
             "description": "TODO: validate color string"
         },
-        "nanAlpha": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 1
-        },
         "useSmoothedBiasContrast": {
             "type": "boolean"
         },
@@ -117,12 +112,10 @@
         "vectorOverlayPixelAveraging": {
             "type": "number",
             "minimum": 0,
-            "maximum": 64,
-            "default": 4
+            "maximum": 64
         },
         "vectorOverlayFractionalIntensity": {
-            "type": "boolean",
-            "default": false
+            "type": "boolean"
         },
         "vectorOverlayThickness": {
             "type": "number",
@@ -134,12 +127,10 @@
         },
         "vectorOverlayColor": {
             "type": "string",
-            "description": "TODO: validate color string",
-            "default": "#ffffff"
+            "description": "TODO: validate color string"
         },
         "vectorOverlayColormap": {
-            "type": "string",
-            "default": "viridis"
+            "type": "string"
         },
         "astColor": {
             "type": "string",
@@ -274,66 +265,52 @@
             "type": "boolean"
         },
         "limitOverlayRedraw": {
-            "type": "boolean",
-            "default": true
+            "type": "boolean"
         },
         "cursorInfoVisible": {
-            "enum": ["always", "activeImage", "hideTiled", "never"],
-            "default": "activeImage"
+            "enum": ["always", "activeImage", "hideTiled", "never"]
         },
         "keepLastUsedFolder": {
-            "type": "boolean",
-            "default": false
+            "type": "boolean"
         },
         "lastUsedFolder": {
-            "type": "string",
-            "default": ""
+            "type": "string"
         },
         "imageMultiPanelEnabled": {
-            "type": "boolean",
-            "default": false
+            "type": "boolean"
         },
         "imagePanelMode": {
-            "enum": ["dynamic", "fixed"],
-            "default": "dynamic"
+            "enum": ["dynamic", "fixed"]
         },
         "imagePanelColumns": {
             "type": "number",
-            "minimum": 1,
-            "default": 2
+            "minimum": 1
         },
         "imagePanelRows": {
             "type": "number",
-            "minimum": 1,
-            "default": 2
+            "minimum": 1
         },
         "statsPanelEnabled": {
-            "type": "boolean",
-            "default": false
+            "type": "boolean"
         },
         "statsPanelMode": {
             "type": "integer",
-            "minimum": 0,
-            "default": 0
+            "minimum": 0
         },
         "telemetryUuid": {
             "type": "string"
         },
         "telemetryMode": {
-            "enum": ["none", "minimal", "usage"],
-            "default": "usage"
+            "enum": ["none", "minimal", "usage"]
         },
         "telemetryConsentShown": {
-            "type": "boolean",
-            "default": false
+            "type": "boolean"
         },
         "telemetryLogging": {
-            "type": "boolean",
-            "default": false
+            "type": "boolean"
         },
         "fileFilterMode": {
-            "enum": ["content", "extension", "all"],
-            "default": "content"
+            "enum": ["content", "extension", "all"]
         },
         "pvAxesOrderReverse": {
             "type": "boolean"
@@ -390,10 +367,6 @@
             "type": "number",
             "minimum": 0.1,
             "description": "PV preview cube size limit, in GB."
-        },
-        "pvPreviewCubeSizeLimitUnit": {
-            "enum": ["TB", "GB", "MB", "kB", "B"],
-            "description": "This is a deprecated preference."
         },
         "logEventList": {
             "type": "array",

--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -60,28 +60,23 @@
         },
         "scalingAlphaLog": {
             "type": "number",
-            "minimum": 0.1,
-            "maximum": 10000
+            "exclusiveMinimum": 0
         },
         "scalingAlphaPower": {
             "type": "number",
-            "minimum": 0.001,
-            "maximum": 1000
+            "exclusiveMinimum": 0
         },
         "scalingAlphaSinh": {
             "type": "number",
-            "minimum": 0.1,
-            "maximum": 3
+            "exclusiveMinimum": 0
         },
         "scalingAlphaAsinh": {
             "type": "number",
-            "minimum": 0.01,
-            "maximum": 3
+            "exclusiveMinimum": 0
         },
         "scalingGamma": {
             "type": "number",
-            "minimum": 0.1,
-            "maximum": 2
+            "exclusiveMinimum": 0
         },
         "nanColorHex": {
             "type": "string",

--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -48,8 +48,7 @@
         },
         "scaling": {
             "type": "integer",
-            "minimum": 0,
-            "maximum": 9
+            "minimum": 0
         },
         "colormap": {
             "type": "string"

--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -76,6 +76,16 @@
         "useSmoothedBiasContrast": {
             "type": "boolean"
         },
+        "renderConfigBias": {
+            "type": "number",
+            "minimum": -1,
+            "maximum": 1
+        },
+        "renderConfigContrast": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 2
+        },
         "contourGeneratorType": {
             "enum": ["start-step-multiplier", "min-max-scaling", "percentages-ref.value", "mean-sigma-list"]
         },
@@ -193,6 +203,11 @@
         "regionDashLength": {
             "type": "integer",
             "minimum": 0,
+            "maximum": 50
+        },
+        "regionLabelOffset": {
+            "type": "number",
+            "minimum": -50,
             "maximum": 50
         },
         "regionType": {

--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -59,9 +59,24 @@
             "minimum": 0,
             "maximum": 100
         },
-        "scalingAlpha": {
+        "scalingAlphaLog": {
             "type": "number",
-            "minimum": 0.1,
+            "minimum": 0.000001,
+            "maximum": 1000000
+        },
+        "scalingAlphaPower": {
+            "type": "number",
+            "minimum": 0.000001,
+            "maximum": 1000000
+        },
+        "scalingAlphaSinh": {
+            "type": "number",
+            "minimum": 0.000001,
+            "maximum": 1000000
+        },
+        "scalingAlphaAsinh": {
+            "type": "number",
+            "minimum": 0.000001,
             "maximum": 1000000
         },
         "scalingGamma": {

--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -49,7 +49,7 @@
         "scaling": {
             "type": "integer",
             "minimum": 0,
-            "maximum": 7
+            "maximum": 9
         },
         "colormap": {
             "type": "string"

--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -48,7 +48,8 @@
         },
         "scaling": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "maximum": 9
         },
         "colormap": {
             "type": "string"

--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -61,28 +61,23 @@
         },
         "scalingAlphaLog": {
             "type": "number",
-            "minimum": 0.000001,
-            "maximum": 1000000
+            "exclusiveMinimum": 0
         },
         "scalingAlphaPower": {
             "type": "number",
-            "minimum": 0.000001,
-            "maximum": 1000000
+            "exclusiveMinimum": 0
         },
         "scalingAlphaSinh": {
             "type": "number",
-            "minimum": 0.000001,
-            "maximum": 1000000
+            "exclusiveMinimum": 0
         },
         "scalingAlphaAsinh": {
             "type": "number",
-            "minimum": 0.000001,
-            "maximum": 1000000
+            "exclusiveMinimum": 0
         },
         "scalingGamma": {
             "type": "number",
-            "minimum": 0.1,
-            "maximum": 2
+            "exclusiveMinimum": 0
         },
         "nanColorHex": {
             "type": "string",

--- a/preferences_schema_2.json
+++ b/preferences_schema_2.json
@@ -60,23 +60,28 @@
         },
         "scalingAlphaLog": {
             "type": "number",
-            "exclusiveMinimum": 0
+            "minimum": 0.1,
+            "maximum": 10000
         },
         "scalingAlphaPower": {
             "type": "number",
-            "exclusiveMinimum": 0
+            "minimum": 0.001,
+            "maximum": 1000
         },
         "scalingAlphaSinh": {
             "type": "number",
-            "exclusiveMinimum": 0
+            "minimum": 0.1,
+            "maximum": 3
         },
         "scalingAlphaAsinh": {
             "type": "number",
-            "exclusiveMinimum": 0
+            "minimum": 0.01,
+            "maximum": 3
         },
         "scalingGamma": {
             "type": "number",
-            "exclusiveMinimum": 0
+            "minimum": 0.1,
+            "maximum": 2
         },
         "nanColorHex": {
             "type": "string",

--- a/workspace_schema_1.json
+++ b/workspace_schema_1.json
@@ -49,7 +49,8 @@
             "properties": {
                 "scaling": {
                     "type": "integer",
-                    "minimum": 0
+                    "minimum": 0,
+                    "maximum": 9
                 },
                 "colorMap": {
                     "type": "string"

--- a/workspace_schema_1.json
+++ b/workspace_schema_1.json
@@ -49,8 +49,7 @@
             "properties": {
                 "scaling": {
                     "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9
+                    "minimum": 0
                 },
                 "colorMap": {
                     "type": "string"

--- a/workspace_schema_1.json
+++ b/workspace_schema_1.json
@@ -50,7 +50,7 @@
                 "scaling": {
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 7
+                    "maximum": 9
                 },
                 "colorMap": {
                     "type": "string"

--- a/workspace_schema_1.json
+++ b/workspace_schema_1.json
@@ -70,7 +70,16 @@
                 "gamma": {
                     "type": "number"
                 },
-                "alpha": {
+                "alphaLog": {
+                    "type": "number"
+                },
+                "alphaPower": {
+                    "type": "number"
+                },
+                "alphaSinh": {
+                    "type": "number"
+                },
+                "alphaAsinh": {
                     "type": "number"
                 },
                 "inverted": {

--- a/workspace_schema_1.json
+++ b/workspace_schema_1.json
@@ -68,28 +68,23 @@
                 },
                 "gamma": {
                     "type": "number",
-                    "minimum": 0.1,
-                    "maximum": 2
+                    "exclusiveMinimum": 0
                 },
                 "alphaLog": {
                     "type": "number",
-                    "minimum": 0.1,
-                    "maximum": 10000
+                    "exclusiveMinimum": 0
                 },
                 "alphaPower": {
                     "type": "number",
-                    "minimum": 0.001,
-                    "maximum": 1000
+                    "exclusiveMinimum": 0
                 },
                 "alphaSinh": {
                     "type": "number",
-                    "minimum": 0.1,
-                    "maximum": 3
+                    "exclusiveMinimum": 0
                 },
                 "alphaAsinh": {
                     "type": "number",
-                    "minimum": 0.01,
-                    "maximum": 3
+                    "exclusiveMinimum": 0
                 },
                 "inverted": {
                     "type": "boolean"

--- a/workspace_schema_1.json
+++ b/workspace_schema_1.json
@@ -68,23 +68,28 @@
                 },
                 "gamma": {
                     "type": "number",
-                    "exclusiveMinimum": 0
+                    "minimum": 0.1,
+                    "maximum": 2
                 },
                 "alphaLog": {
                     "type": "number",
-                    "exclusiveMinimum": 0
+                    "minimum": 0.1,
+                    "maximum": 10000
                 },
                 "alphaPower": {
                     "type": "number",
-                    "exclusiveMinimum": 0
+                    "minimum": 0.001,
+                    "maximum": 1000
                 },
                 "alphaSinh": {
                     "type": "number",
-                    "exclusiveMinimum": 0
+                    "minimum": 0.1,
+                    "maximum": 3
                 },
                 "alphaAsinh": {
                     "type": "number",
-                    "exclusiveMinimum": 0
+                    "minimum": 0.01,
+                    "maximum": 3
                 },
                 "inverted": {
                     "type": "boolean"

--- a/workspace_schema_1.json
+++ b/workspace_schema_1.json
@@ -67,19 +67,24 @@
                     "type": "number"
                 },
                 "gamma": {
-                    "type": "number"
+                    "type": "number",
+                    "exclusiveMinimum": 0
                 },
                 "alphaLog": {
-                    "type": "number"
+                    "type": "number",
+                    "exclusiveMinimum": 0
                 },
                 "alphaPower": {
-                    "type": "number"
+                    "type": "number",
+                    "exclusiveMinimum": 0
                 },
                 "alphaSinh": {
-                    "type": "number"
+                    "type": "number",
+                    "exclusiveMinimum": 0
                 },
                 "alphaAsinh": {
-                    "type": "number"
+                    "type": "number",
+                    "exclusiveMinimum": 0
                 },
                 "inverted": {
                     "type": "boolean"


### PR DESCRIPTION
Update preference and workspace schemas for sinh/asinh scaling.

This PR is based on the branch from [#15](https://github.com/CARTAvis/schemas/pull/15) and cannot be merged until #15 is merged.

- Remove the maximum constraint from scaling values to support Sinh and Asinh while allowing forward-compatible scaling types.
- Replace the single alpha field with per-scaling alpha fields for Log, Power, Sinh, and Asinh.
- Add scaling-specific validation ranges for the alpha and gamma fields.

Companion frontend PR: https://github.com/CARTAvis/carta-frontend/pull/2825/