### PR TITLE
adds field for site scoped snippets

### DIFF
--- a/snippet_schema_1.json
+++ b/snippet_schema_1.json
@@ -27,6 +27,10 @@
                 "type": "string"
             }
         },
+        "siteScoped": {
+            "description": "Whether this snippet is site-scoped and shared across users",
+            "type": "boolean"
+        },
         "categories": {
             "description": "List of categories under which to place this snippet",
             "type": "array",


### PR DESCRIPTION
Non-breaking change to add an optional `siteScoped` field to the snippet schema, so that we can define snippets shared across an entire site, rather than a single user